### PR TITLE
Update Cherries Product to include ProductionRegions

### DIFF
--- a/[Shared] Extended Products (Kurila)/data/products/cherries/assets.include.xml
+++ b/[Shared] Extended Products (Kurila)/data/products/cherries/assets.include.xml
@@ -16,6 +16,16 @@
           <BasePrice>25</BasePrice>
           <CivLevel>1</CivLevel>
           <AssociatedRegion>Moderate</AssociatedRegion>
+          <ProductionRegions>
+            <Item>
+              <RegionType>Moderate</RegionType>
+              <RequiredDLCs>
+                <Item>
+                  <RequiredDLC>410084</RequiredDLC>
+                </Item>
+              </RequiredDLCs>
+            </Item>
+          </ProductionRegions>
         </Product>
         <ExpeditionAttribute>
           <BaseMorale>0</BaseMorale>


### PR DESCRIPTION
Cherries are missing the ProductionRegion Tag, leading to warning in multifactory recipes bc no region is set for the production.